### PR TITLE
Use Clang as the C Compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_C_STANDARD 17)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 set(STANDARD_C_VERSION_FLAG "-std=c17")
 set(OPTIMIZE_FLAG "-O3")
-set(WARNING_FLAGS "-Werror -Wpedantic -Wall -Wextra -Wno-return-local-addr -Wno-maybe-uninitialized")
+set(WARNING_FLAGS "-Werror -Wpedantic -Wall -Wextra -Wno-return-stack-address -Wno-uninitialized")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${STANDARD_C_VERSION_FLAG} ${OPTIMIZE_FLAG} ${WARNING_FLAGS}")
 
 file(COPY static DESTINATION ${CMAKE_BINARY_DIR})

--- a/generate_build.sh
+++ b/generate_build.sh
@@ -1,0 +1,1 @@
+cmake -B build -DCMAKE_C_COMPILER='clang'

--- a/main.c
+++ b/main.c
@@ -216,16 +216,12 @@ int main() {
 			strncat(file_route, "/index.html", 100);
 		}
 		
-
 		// find if requested file exists in web server
 		char* file_name = find_requested_html_file(file_route, "static");
 		printf("Found file %s\n", file_name);
 
 		// read HTML file
 		char* buf = read_html_file(file_name);
-
-	
-		printf("Scream");
 
 		// Store HTML char pointer data
 		char response[MAX_HTML_CHARACTER_LIMIT+100] = "HTTP/1.1 200 OK\n\n";


### PR DESCRIPTION
Wrote a shell script to generate a build directory which uses the **Clang** as the C compiler. Updated the warning flags for it to work with Clang.